### PR TITLE
Opção de mais de um scope

### DIFF
--- a/gtc.py
+++ b/gtc.py
@@ -121,7 +121,7 @@ def add_to_playlist(arg1, url, user_id, playlist_id):
     track_id = url.split('/track/')[1]
     track_id = 'spotify:track:' + track_id
     print(track_id)
-    scope = 'playlist-modify-private'
+    scope = 'playlist-modify-public playlist-modify-private'
     sp_token = util.prompt_for_user_token(user_id, scope,
         client_id = config[arg1]['CLIENT_ID'],
         client_secret = config[arg1]['CLIENT_SECRET'],


### PR DESCRIPTION
De modo à permitir a opção de usar playlists públicas também, foi adicionado mais um scope na lista de scopes. qualquer dúvida pode ser consultada pela documentação no seguinte link: https://developer.spotify.com/web-api/using-scopes/

Essa alteração tem como objetivo resolver a issue #4  